### PR TITLE
Moving gc calls to garbageCollect on v3

### DIFF
--- a/src/Session/SaveHandler/DynamoDb.php
+++ b/src/Session/SaveHandler/DynamoDb.php
@@ -99,6 +99,9 @@ class DynamoDb implements SaveHandlerInterface
      * Trigger garbage collection on expired sessions
      *
      * Part of the standard PHP session handler interface
+     * 
+     * On aws v3, the gc method does nothing, please use garbageCollect()
+     * @see http://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.DynamoDb.SessionHandler.html#_garbageCollect
      *
      * @param int $maxlifetime The value of `session.gc_maxlifetime`. Ignored.
      *
@@ -106,18 +109,19 @@ class DynamoDb implements SaveHandlerInterface
      */
     public function gc($maxlifetime)
     {
-        return $this->sessionHandler->gc($maxlifetime);
+        $this->sessionHandler->garbageCollect();
+        return true;
     }
     
     /**
      * Manually trigger garbage collection on expired sessions.
      * 
-     * Recommended way if auto garbage collection if off.
+     * On v3, this must be used for garbage collection, as the "gc" method does nothing.
      * 
-     * @see https://docs.aws.amazon.com/aws-sdk-php/v2/api/class-Aws.DynamoDb.Session.SessionHandler.html#_garbageCollect
+     * @see http://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.DynamoDb.SessionHandler.html#_garbageCollect
      */
     public function garbageCollect()
     {
-        return $this->sessionHandler->garbageCollect();
+        $this->sessionHandler->garbageCollect();
     }
 }

--- a/src/Session/SaveHandler/DynamoDb.php
+++ b/src/Session/SaveHandler/DynamoDb.php
@@ -100,28 +100,24 @@ class DynamoDb implements SaveHandlerInterface
      *
      * Part of the standard PHP session handler interface
      *
-     * On aws v3, the gc method does nothing, please use garbageCollect()
-     * @see http://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.DynamoDb.SessionHandler.html#_garbageCollect
-     *
      * @param int $maxlifetime The value of `session.gc_maxlifetime`. Ignored.
      *
      * @return bool Whether or not the operation succeeded
      */
     public function gc($maxlifetime)
     {
-        $this->sessionHandler->garbageCollect();
-        return true;
+        return $this->sessionHandler->gc($maxlifetime);
     }
 
     /**
      * Manually trigger garbage collection on expired sessions.
      *
-     * On v3, this must be used for garbage collection, as the "gc" method does nothing.
+     * Recommended way if auto garbage collection if off.
      *
-     * @see http://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.DynamoDb.SessionHandler.html#_garbageCollect
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v2/api/class-Aws.DynamoDb.Session.SessionHandler.html#_garbageCollect
      */
     public function garbageCollect()
     {
-        $this->sessionHandler->garbageCollect();
+        return $this->sessionHandler->garbageCollect();
     }
 }

--- a/src/Session/SaveHandler/DynamoDb.php
+++ b/src/Session/SaveHandler/DynamoDb.php
@@ -108,4 +108,16 @@ class DynamoDb implements SaveHandlerInterface
     {
         return $this->sessionHandler->gc($maxlifetime);
     }
+    
+    /**
+     * Manually trigger garbage collection on expired sessions.
+     * 
+     * Recommended way if auto garbage collection if off.
+     * 
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v2/api/class-Aws.DynamoDb.Session.SessionHandler.html#_garbageCollect
+     */
+    public function garbageCollect()
+    {
+        return $this->sessionHandler->garbageCollect();
+    }
 }

--- a/src/Session/SaveHandler/DynamoDb.php
+++ b/src/Session/SaveHandler/DynamoDb.php
@@ -99,7 +99,7 @@ class DynamoDb implements SaveHandlerInterface
      * Trigger garbage collection on expired sessions
      *
      * Part of the standard PHP session handler interface
-     * 
+     *
      * On aws v3, the gc method does nothing, please use garbageCollect()
      * @see http://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.DynamoDb.SessionHandler.html#_garbageCollect
      *
@@ -112,12 +112,12 @@ class DynamoDb implements SaveHandlerInterface
         $this->sessionHandler->garbageCollect();
         return true;
     }
-    
+
     /**
      * Manually trigger garbage collection on expired sessions.
-     * 
+     *
      * On v3, this must be used for garbage collection, as the "gc" method does nothing.
-     * 
+     *
      * @see http://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.DynamoDb.SessionHandler.html#_garbageCollect
      */
     public function garbageCollect()

--- a/tests/Session/SaveHandler/DynamoDbTest.php
+++ b/tests/Session/SaveHandler/DynamoDbTest.php
@@ -103,7 +103,8 @@ class DynamoDbTest extends \PHPUnit_Framework_TestCase
     public function testSessionHandlerGcIsCalled()
     {
         $this->sessionHandler->expects($this->once())
-            ->method('garbageCollect')
+            ->method('gc')
+            ->with($this->equalTo(420))
             ->will($this->returnValue(true));
 
         $result = $this->saveHandler->gc(420);

--- a/tests/Session/SaveHandler/DynamoDbTest.php
+++ b/tests/Session/SaveHandler/DynamoDbTest.php
@@ -30,6 +30,7 @@ class DynamoDbTest extends \PHPUnit_Framework_TestCase
                 'write',
                 'destroy',
                 'gc',
+                'garbageCollect',
             ],
             [],
             '',
@@ -102,12 +103,22 @@ class DynamoDbTest extends \PHPUnit_Framework_TestCase
     public function testSessionHandlerGcIsCalled()
     {
         $this->sessionHandler->expects($this->once())
-            ->method('gc')
-            ->with($this->equalTo(420))
+            ->method('garbageCollect')
             ->will($this->returnValue(true));
 
         $result = $this->saveHandler->gc(420);
 
         $this->assertTrue($result);
+    }
+
+    public function testSessionHandlerGarbageCollectIsCalled()
+    {
+        $this->sessionHandler->expects($this->once())
+        ->method('garbageCollect')
+        ->will($this->returnValue(null));
+
+        $result = $this->saveHandler->garbageCollect();
+
+        $this->assertNull($result);
     }
 }


### PR DESCRIPTION
On v3, as in [official doc](http://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.DynamoDb.SessionHandler.html#_gc), the gc method does nothing anymore (found out the hard way :)), must call garbageCollect().