### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "zendframework/zend-view": "^2.8"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.*",
+    "phpunit/phpunit": "^4.8.35",
     "zendframework/zend-modulemanager": "2.7.*",
     "squizlabs/php_codesniffer": "~2.3"
   },

--- a/tests/Factory/AwsFactoryTest.php
+++ b/tests/Factory/AwsFactoryTest.php
@@ -6,11 +6,12 @@ use AwsModule\Factory\AwsFactory;
 use Aws\Sdk as AwsSdk;
 use AwsModule\Module;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * AWS Module test cases
  */
-class AwsFactoryTest extends \PHPUnit_Framework_TestCase
+class AwsFactoryTest extends TestCase
 {
     public function testCanFetchAwsFromServiceManager()
     {

--- a/tests/Factory/DynamoDbSessionSaveHandlerFactoryTest.php
+++ b/tests/Factory/DynamoDbSessionSaveHandlerFactoryTest.php
@@ -6,11 +6,12 @@ use AwsModule\Factory\DynamoDbSessionSaveHandlerFactory;
 use Aws\Sdk as AwsSdk;
 use AwsModule\Session\SaveHandler\DynamoDb as DynamoDbSaveHandler;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * DynamoDB-backed session save handler tests
  */
-class DynamoDbSessionSaveHandlerFactoryTest extends \PHPUnit_Framework_TestCase
+class DynamoDbSessionSaveHandlerFactoryTest extends TestCase
 {
     public function testCanFetchSaveHandlerFromServiceManager()
     {

--- a/tests/Filter/File/S3RenameUploadTest.php
+++ b/tests/Filter/File/S3RenameUploadTest.php
@@ -6,8 +6,9 @@ use AwsModule\Filter\Exception\MissingBucketException;
 use AwsModule\Filter\File\S3RenameUpload;
 use Aws\S3\S3Client;
 use ReflectionMethod;
+use PHPUnit\Framework\TestCase;
 
-class S3RenameUploadTest extends \PHPUnit_Framework_TestCase
+class S3RenameUploadTest extends TestCase
 {
     /**
      * @var S3RenameUpload

--- a/tests/Session/SaveHandler/DynamoDbTest.php
+++ b/tests/Session/SaveHandler/DynamoDbTest.php
@@ -4,8 +4,9 @@ namespace AwsModule\Tests\Session\SaveHandler;
 
 use Aws\DynamoDb\SessionHandler;
 use AwsModule\Session\SaveHandler\DynamoDb as DynamoDbSaveHandler;
+use PHPUnit\Framework\TestCase;
 
-class DynamoDbTest extends \PHPUnit_Framework_TestCase
+class DynamoDbTest extends TestCase
 {
     /**
      * @var SessionHandler

--- a/tests/View/Helper/CloudFrontLinkTest.php
+++ b/tests/View/Helper/CloudFrontLinkTest.php
@@ -4,8 +4,9 @@ namespace AwsModule\Tests\View\Helper;
 
 use Aws\CloudFront\CloudFrontClient;
 use AwsModule\View\Helper\CloudFrontLink;
+use PHPUnit\Framework\TestCase;
 
-class CloudFrontLinkTest extends \PHPUnit_Framework_TestCase
+class CloudFrontLinkTest extends TestCase
 {
     /**
      * @var CloudFrontClient

--- a/tests/View/Helper/S3LinkTest.php
+++ b/tests/View/Helper/S3LinkTest.php
@@ -4,8 +4,9 @@ namespace AwsModule\Tests\View\Helper;
 
 use Aws\S3\S3Client;
 use AwsModule\View\Helper\S3Link;
+use PHPUnit\Framework\TestCase;
 
-class S3LinkTest extends \PHPUnit_Framework_TestCase
+class S3LinkTest extends TestCase
 {
     /**
      * @var S3Client


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.