### PR TITLE
Issue #51 - Relax version constraint on zend-session

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "aws/aws-sdk-php": "3.*",
     "zendframework/zend-filter": "2.7.*",
     "zendframework/zend-servicemanager": "2.7.* || 3.*",
-    "zendframework/zend-session": "2.7.*",
+    "zendframework/zend-session": "^2.7.0",
     "zendframework/zend-view": "^2.8"
   },
   "require-dev": {


### PR DESCRIPTION
Addresses #51 

Relaxes version constraint on zend-session, to allow installation of this module with php 7.2 compatible releases of zend-session