### PR TITLE
Relax zend framework package constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
   "require": {
     "php": "^5.6 || ^7.0",
     "aws/aws-sdk-php": "3.*",
-    "zendframework/zend-filter": "2.7.*",
-    "zendframework/zend-servicemanager": "2.7.* || 3.*",
+    "zendframework/zend-filter": "^2.7.0",
+    "zendframework/zend-servicemanager": "^2.7.0 || ^3.0",
     "zendframework/zend-session": "^2.7.0",
     "zendframework/zend-view": "^2.8"
   },


### PR DESCRIPTION
This will allow the newest version of zend-filter (2.8.0) to be used. 