### PR TITLE
Relax version constraint on zend filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": "^5.6 || ^7.0",
     "aws/aws-sdk-php": "3.*",
-    "zendframework/zend-filter": "2.7.*",
+    "zendframework/zend-filter": "^2.7.0",
     "zendframework/zend-servicemanager": "2.7.* || 3.*",
     "zendframework/zend-session": "^2.7.0",
     "zendframework/zend-view": "^2.8"


### PR DESCRIPTION
Related to https://github.com/aws/aws-sdk-php-zf2/pull/52, v2.8.0 add PHP 7.2 support for zend filters and this will allow to use latest zend filter.