### PR TITLE
compatible zend-filter 2.9.0 for RenameUpload::getFinalTarget()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
   "require": {
     "php": "^5.6 || ^7.0",
     "aws/aws-sdk-php": "3.*",
-    "zendframework/zend-filter": "^2.7.0",
+    "zendframework/zend-filter": "^2.9.0",
     "zendframework/zend-servicemanager": "^2.7.0 || ^3.0",
     "zendframework/zend-session": "^2.7.0",
     "zendframework/zend-view": "^2.8"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.*",
+    "phpunit/phpunit": "5.*",
     "zendframework/zend-modulemanager": "2.7.*",
     "squizlabs/php_codesniffer": "~2.3"
   },

--- a/src/Filter/File/S3RenameUpload.php
+++ b/src/Filter/File/S3RenameUpload.php
@@ -69,7 +69,7 @@ class S3RenameUpload extends RenameUpload
      *
      * {@inheritdoc}
      */
-    protected function getFinalTarget($uploadData)
+    protected function getFinalTarget($source, $clientFileName)
     {
         // We cannot upload without a bucket
         if (null === $this->options['bucket']) {
@@ -77,7 +77,7 @@ class S3RenameUpload extends RenameUpload
         }
 
         // Get the tmp file name and convert it to an S3 key
-        $key = trim(str_replace('\\', '/', parent::getFinalTarget($uploadData)), '/');
+        $key = trim(str_replace('\\', '/', parent::getFinalTarget($source, $clientFileName)), '/');
         if (strpos($key, './') === 0) {
             $key = substr($key, 2);
         }

--- a/tests/Factory/AwsFactoryTest.php
+++ b/tests/Factory/AwsFactoryTest.php
@@ -43,7 +43,7 @@ class AwsFactoryTest extends \PHPUnit_Framework_TestCase
 
     private function getMockServiceLocator()
     {
-        $serviceLocator = $this->getMock(ServiceLocatorInterface::class);
+        $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
         $serviceLocator
             ->expects($this->once())
             ->method('get')

--- a/tests/Factory/DynamoDbSessionSaveHandlerFactoryTest.php
+++ b/tests/Factory/DynamoDbSessionSaveHandlerFactoryTest.php
@@ -30,7 +30,7 @@ class DynamoDbSessionSaveHandlerFactoryTest extends \PHPUnit_Framework_TestCase
 
         $awsSdk = new AwsSdk($config['aws']);
 
-        $serviceLocator = $this->getMock(ServiceLocatorInterface::class);
+        $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
         $serviceLocator->expects($this->at(0))->method('get')->with('Config')->willReturn($config);
         $serviceLocator->expects($this->at(1))->method('get')->with(AwsSdk::class)->willReturn($awsSdk);
 
@@ -48,7 +48,7 @@ class DynamoDbSessionSaveHandlerFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testExceptionThrownWhenSaveHandlerConfigurationDoesNotExist()
     {
-        $serviceLocator = $this->getMock(ServiceLocatorInterface::class);
+        $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
         $serviceLocator->expects($this->once())->method('get')->with('Config')->willReturn([]);
 
         $saveHandlerFactory = new DynamoDbSessionSaveHandlerFactory();

--- a/tests/Filter/File/S3RenameUploadTest.php
+++ b/tests/Filter/File/S3RenameUploadTest.php
@@ -47,7 +47,7 @@ class S3RenameUploadTest extends \PHPUnit_Framework_TestCase
     public function testThrowExceptionIfNoBucketIsSet()
     {
         $this->setExpectedException(MissingBucketException::class);
-        $this->filter->filter(['tmp_name' => 'foo']);
+        $this->filter->filter(['tmp_name' => 'foo', 'name' => 'foo']);
     }
 
     /**
@@ -60,9 +60,7 @@ class S3RenameUploadTest extends \PHPUnit_Framework_TestCase
 
         $this->filter->setBucket('my-bucket');
 
-        $result = $reflMethod->invoke($this->filter, [
-            'tmp_name' => $tmpName
-        ]);
+        $result = $reflMethod->invokeArgs($this->filter, [$tmpName, $tmpName]);
 
         $this->assertEquals("s3://my-bucket/{$expectedKey}", $result);
     }

--- a/tests/Session/SaveHandler/DynamoDbTest.php
+++ b/tests/Session/SaveHandler/DynamoDbTest.php
@@ -21,7 +21,7 @@ class DynamoDbTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->sessionHandler = $this->getMock(
+        $this->sessionHandler = $this->createMock(
             SessionHandler::class,
             [
                 'open',


### PR DESCRIPTION
Latest `dev-master` build got travis build error because it tried to install latest zend-filter and current latest zend-filter 2.9.0 has different method signature for `RenameUpload::getFinalTarget()`. I updated the `AwsModule\Filter\File\S3RenameUpload::getFinalTarget()` to use it:

```php
protected function getFinalTarget($source, $clientFileName)
```

and also update the required zend-filter to use `^2.9.0` so the compatible code will work for user with latest zend-filter ^2.9.0 only. Phpunit is also updated to as now is also updated to not get deprecated code notice.